### PR TITLE
Add support for database configuration

### DIFF
--- a/src/KormBuilder.cs
+++ b/src/KormBuilder.cs
@@ -18,6 +18,7 @@ namespace Kros.KORM.Extensions.Asp
     public class KormBuilder
     {
         private ConnectionStringSettings _connectionString;
+        private IDatabaseBuilder _builder;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KormBuilder"/> class.
@@ -28,12 +29,39 @@ namespace Kros.KORM.Extensions.Asp
         {
             Services = Check.NotNull(services, nameof(services));
             _connectionString = Check.NotNull(connectionString, nameof(connectionString));
+
+            _builder = Database.Builder;
+            _builder.UseConnection(connectionString);
         }
 
         /// <summary>
         /// Gets the service collection.
         /// </summary>
         public IServiceCollection Services { get; }
+
+        /// <summary>
+        /// Use database configuration.
+        /// </summary>
+        /// <typeparam name="TConfiguration">Configuration type.</typeparam>
+        /// <returns>KORM builder.</returns>
+        public KormBuilder UseDatabaseConfiguration<TConfiguration>() where TConfiguration : DatabaseConfigurationBase, new()
+        {
+            _builder.UseDatabaseConfiguration<TConfiguration>();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Use database configuration.
+        /// </summary>
+        /// <param name="databaseConfiguration">Instance of database configuration.</param>
+        /// <returns>KORM builder.</returns>
+        public KormBuilder UseDatabaseConfiguration(DatabaseConfigurationBase databaseConfiguration)
+        {
+            _builder.UseDatabaseConfiguration(databaseConfiguration);
+
+            return this;
+        }
 
         /// <summary>
         /// Initializes database for using Id generator.
@@ -126,5 +154,7 @@ namespace Kros.KORM.Extensions.Asp
                     .Wait();
             }
         }
+
+        internal IDatabase Build() => _builder.Build();
     }
 }

--- a/src/Kros.KORM.Extensions.Asp.csproj
+++ b/src/Kros.KORM.Extensions.Asp.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kros.KORM" Version="3.9.0" />
+    <PackageReference Include="Kros.KORM" Version="4.0.0-alfa2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -82,13 +82,14 @@ namespace Kros.KORM.Extensions.Asp
 
             var connectionString = configurationSection.Get<ConnectionStringSettings>();
             CheckOptions(connectionString);
+            var builder = new KormBuilder(services, connectionString);
 
             services.AddScoped<IDatabase>((serviceProvider) =>
             {
-                return new Database(connectionString);
+                return builder.Build();
             });
 
-            return new KormBuilder(services, connectionString);
+            return builder;
         }
 
         private static void CheckOptions(ConnectionStringSettings connectionString)

--- a/tests/KormBuilderShould.cs
+++ b/tests/KormBuilderShould.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kros.Data;
 using Kros.KORM.Extensions.Asp;
+using Kros.KORM.Metadata;
 using Kros.KORM.Migrations;
 using Kros.UnitTests;
 using Microsoft.Extensions.DependencyInjection;
@@ -94,6 +95,19 @@ namespace Kros.KORM.Extensions.Api.UnitTests
             kormBuilder.Migrate();
 
             migrationRunner.DidNotReceive().MigrateAsync();
+        }
+
+        [Fact]
+        public void UseDatabaseConfiguration()
+        {
+            var kormBuilder = CreateKormBuilder();
+            var configuration = Substitute.For<DatabaseConfigurationBase>();
+
+            kormBuilder.UseDatabaseConfiguration(configuration);
+            var database = kormBuilder.Build();
+
+            database.Should().NotBeNull();
+            configuration.Received().OnModelCreating(Arg.Any<ModelConfigurationBuilder>());
         }
 
         private void CheckTableAndProcedure()


### PR DESCRIPTION
Add support for DatabaseConfiguration which brings new version of KORM.

```CSharp
public void ConfigureServices(IServiceCollection services)
{
  services.AddKorm(Configuration)
	.AddKormMigrations(Configuration)
        .UseDatabaseConfiguration<DatabaseCofiguration>()
	.Migrate();
}
```
