### PR TITLE
Migrations middleware supports multiple databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,33 +89,43 @@ CONSTRAINT [PK_People] PRIMARY KEY CLUSTERED ([Id] ASC)
 GO
 ```
 
-Migration can also be executed through an HTTP request. By calling the `/kormmigration` endpoint, the necessary migrations will be executed.
-However, you need to add middleware:
+Migration can also be executed through an HTTP request. By calling the `/kormmigration` endpoint, the necessary migrations will be executed. However, you need to add middleware:
 
 ``` csharp
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
-  app.UseKormMigrations(o =>
-  {
-    o.EndpointUrl = "/kormmigration";
-  });
+    app.UseKormMigrations();
 }
 ```
+
+You can change the endpoint URL by configuration:
+
+``` csharp
+public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+{
+    app.UseKormMigrations(options =>
+    {
+        options.EndpointUrl = "/loremipsum";
+    });
+}
+```
+
+If multiple KORM databases are registered, all of them have unique name. Migrations are performed per database and the name of the database is specified in URL as another path segment: `/kormmigration/dbname` If the name is not specified, default connection string will be used (`DefaultConnection`).
 
 If you have scripts stored in a different way (for example, somewhere on a disk or in another assembly), you can configure your own providers to get these scripts.
 
 ``` csharp
 public void ConfigureServices(IServiceCollection services)
 {
-  services.AddKorm(Configuration)
-    .AddKormMigrations(o =>
-    {
-        var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.FullName.StartWith("Demo.DatabaseLayer"));
-        o.AddAssemblyScriptsProvider(assembly, "Demo.DatabaseLayer.Resources");
-        o.AddFileScriptsProvider(@"C:\scripts\");
-        o.AddScriptsProvider(new MyCustomScriptsProvider());
-    })
-    .Migrate();
+    services.AddKorm(Configuration)
+        .AddKormMigrations(o =>
+        {
+            var assembly = AppDomain.CurrentDomain.GetAssemblies()    .FirstOrDefault(x => x.FullName.StartWith  ("Demo.DatabaseLayer")  );
+            o.AddAssemblyScriptsProvider(assembly,     "Demo.DatabaseLayer.Resources");
+            o.AddFileScriptsProvider(@"C:\scripts\");
+            o.AddScriptsProvider(new MyCustomScriptsProvider());
+        })
+        .Migrate();
 }
 ```
 

--- a/src/DatabaseFactory.cs
+++ b/src/DatabaseFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.KORM.Extensions.Asp.Properties;
+using Kros.KORM.Migrations;
 using Kros.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -44,6 +45,18 @@ namespace Kros.KORM.Extensions.Asp
 
         IDatabase IDatabaseFactory.GetDatabase(string name)
         {
+            KormBuilder builder = GetBuilder(name);
+            return _databases.GetOrAdd(name, _ => builder.Build());
+        }
+
+        IMigrationsRunner IDatabaseFactory.GetMigrationsRunner(string name)
+        {
+            KormBuilder builder = GetBuilder(name);
+            return builder.MigrationsRunner;
+        }
+
+        private KormBuilder GetBuilder(string name)
+        {
             if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(DatabaseFactory));
@@ -56,7 +69,7 @@ namespace Kros.KORM.Extensions.Asp
                     string.Format(Resources.InvalidDatabaseName, name, nameof(ServiceCollectionExtensions.AddKorm)),
                     nameof(name));
             }
-            return _databases.GetOrAdd(name, _ => builder.Build());
+            return builder;
         }
 
         public void Dispose()

--- a/src/DatabaseFactory.cs
+++ b/src/DatabaseFactory.cs
@@ -23,7 +23,7 @@ namespace Kros.KORM.Extensions.Asp
         /// <param name="name">The name of the database builder.</param>
         /// <param name="builder">Database builder.</param>
         /// <returns><see langword="true"/>, if this was the first builder added, otherwise <see langword="false"/>.</returns>
-        internal static bool AddBuilder(IServiceCollection services, string name, KormBuilder builder)
+        internal static void AddBuilder(IServiceCollection services, string name, KormBuilder builder)
         {
             Dictionary<string, KormBuilder> builders = AddBuildersDictionary(services);
             if (builders.ContainsKey(name))
@@ -31,10 +31,6 @@ namespace Kros.KORM.Extensions.Asp
                 throw new ArgumentException(string.Format(Resources.DuplicateDatabaseName, name), nameof(name));
             }
             builders.Add(name, builder);
-
-            // We need to know if it was the first builder added.
-            // The first builder is added into the service container also as IDatabase dependency.
-            return builders.Count == 1;
         }
 
         private readonly ConcurrentDictionary<string, IDatabase> _databases = new ConcurrentDictionary<string, IDatabase>();

--- a/src/IDatabaseFactory.cs
+++ b/src/IDatabaseFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Kros.KORM.Migrations;
+using System;
 
 namespace Kros.KORM.Extensions.Asp
 {
@@ -22,5 +23,25 @@ namespace Kros.KORM.Extensions.Asp
         /// </list>
         /// </exception>
         IDatabase GetDatabase(string name);
+
+        /// <summary>
+        /// Returns the migrations runner for database with specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">Name of the database.</param>
+        /// <returns>Implementation of <see cref="IMigrationsRunner"/> or <see langword="null"/>.</returns>
+        /// <remarks>
+        /// Migrations must be added by <see cref="KormBuilder.AddKormMigrations(Action{MigrationOptions})"/>.
+        /// If migrations was not added for specified database, this method returns <see langword="null"/>.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">The value of <paramref name="name"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">
+        /// The value of <paramref name="name"/> is:
+        /// <list type="bullet">
+        /// <item>Empty string.</item>
+        /// <item>String containing whitespace characters.</item>
+        /// <item>Ivalid name. The database with that name is not registered.</item>
+        /// </list>
+        /// </exception>
+        IMigrationsRunner GetMigrationsRunner(string name);
     }
 }

--- a/src/Kros.KORM.Extensions.Asp.csproj
+++ b/src/Kros.KORM.Extensions.Asp.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kros.KORM" Version="4.0.0-alpha.6" />
+    <PackageReference Include="Kros.KORM" Version="4.0.0-alpha.8" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />

--- a/src/Kros.KORM.Extensions.Asp.csproj
+++ b/src/Kros.KORM.Extensions.Asp.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kros.KORM" Version="4.0.0-alfa5" />
+    <PackageReference Include="Kros.KORM" Version="4.0.0-alpha.6" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />

--- a/src/Migrations/Middleware/MigrationMiddlewareOptions.cs
+++ b/src/Migrations/Middleware/MigrationMiddlewareOptions.cs
@@ -8,9 +8,9 @@ namespace Kros.KORM.Migrations.Middleware
     public class MigrationMiddlewareOptions
     {
         /// <summary>
-        /// Migrations endpoint URL.
+        /// Migrations endpoint URL. Default value is <c>/kormmigration</c>.
         /// </summary>
-        public string EndpointUrl { get; set; } = "/kormmigrate";
+        public string EndpointUrl { get; set; } = "/kormmigration";
 
         /// <summary>
         /// Minimum time between two migrations.

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Kros.KORM.Extensions.Asp.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connection string in connection settings is empty..
+        /// </summary>
+        internal static string EmptyConnectionStringInSettings {
+            get {
+                return ResourceManager.GetString("EmptyConnectionStringInSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Connection strings section does not contain a connection string with name &apos;{0}&apos;..
         /// </summary>
         internal static string InvalidConnectionStringName {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -124,6 +124,9 @@
     <value>Database with name "{0}" was already added.</value>
     <comment>0 - name of the database/connection string</comment>
   </data>
+  <data name="EmptyConnectionStringInSettings" xml:space="preserve">
+    <value>Connection string in connection settings is empty.</value>
+  </data>
   <data name="InvalidConnectionStringName" xml:space="preserve">
     <value>Connection strings section does not contain a connection string with name '{0}'.</value>
     <comment>0 - connection string name in appsettings</comment>

--- a/tests/KormBuilderShould.cs
+++ b/tests/KormBuilderShould.cs
@@ -20,23 +20,17 @@ namespace Kros.KORM.Extensions.Api.UnitTests
             Action action = () => new KormBuilder(null, connectionString);
             action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("services");
 
-            action = () => new KormBuilder(services, null);
+            action = () => new KormBuilder(services, (string)null);
             action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("connectionString");
+
+            action = () => new KormBuilder(services, (KormConnectionSettings)null);
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("connectionSettings");
 
             action = () => new KormBuilder(services, string.Empty);
             action.Should().Throw<ArgumentException>().And.ParamName.Should().Be("connectionString");
 
             action = () => new KormBuilder(services, " \t ");
             action.Should().Throw<ArgumentException>().And.ParamName.Should().Be("connectionString");
-
-            action = () => new KormBuilder(services, connectionString, false, null);
-            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("kormProvider");
-
-            action = () => new KormBuilder(services, connectionString, false, string.Empty);
-            action.Should().Throw<ArgumentException>().And.ParamName.Should().Be("kormProvider");
-
-            action = () => new KormBuilder(services, connectionString, false, " \t ");
-            action.Should().Throw<ArgumentException>().And.ParamName.Should().Be("kormProvider");
         }
 
         [Fact]
@@ -80,6 +74,6 @@ namespace Kros.KORM.Extensions.Api.UnitTests
         }
 
         private KormBuilder CreateKormBuilder(bool autoMigrate)
-            => new KormBuilder(new ServiceCollection(), "server=localhost", autoMigrate);
+            => new KormBuilder(new ServiceCollection(), $"server=localhost;KormAutoMigrate={autoMigrate}");
     }
 }

--- a/tests/KormBuilderShould.cs
+++ b/tests/KormBuilderShould.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Kros.KORM.Extensions.Asp;
 using Kros.KORM.Metadata;
-using Kros.KORM.Migrations;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using System;
@@ -31,33 +30,6 @@ namespace Kros.KORM.Extensions.Api.UnitTests
 
             action = () => new KormBuilder(services, " \t ");
             action.Should().Throw<ArgumentException>().And.ParamName.Should().Be("connectionString");
-        }
-
-        [Fact]
-        public void AddMigrationsToContainer()
-        {
-            KormBuilder kormBuilder = CreateKormBuilder(false);
-            kormBuilder.AddKormMigrations();
-
-            kormBuilder.Services.BuildServiceProvider()
-                .GetService<IMigrationsRunner>()
-                .Should().NotBeNull();
-        }
-
-        [Theory]
-        [InlineData(true, 1)]
-        [InlineData(false, 0)]
-        public void ExecuteMigrationsBasedOnAutoMigrateValue(bool autoMigrate, int migrateCallCount)
-        {
-            KormBuilder kormBuilder = CreateKormBuilder(autoMigrate);
-            kormBuilder.AddKormMigrations();
-
-            IMigrationsRunner migrationRunner = Substitute.For<IMigrationsRunner>();
-            kormBuilder.Services.AddSingleton(migrationRunner);
-
-            kormBuilder.Migrate();
-
-            migrationRunner.Received(migrateCallCount).MigrateAsync();
         }
 
         [Fact]

--- a/tests/KormBuilderWithDatabaseShould.cs
+++ b/tests/KormBuilderWithDatabaseShould.cs
@@ -29,14 +29,11 @@ namespace Kros.KORM.Extensions.Api.UnitTests
         [Fact]
         public void InitDatabaseForIdGenerator()
         {
-            KormBuilder kormBuilder = CreateKormBuilder(false);
+            var kormBuilder = new KormBuilder(new ServiceCollection(), ServerHelper.Connection.ConnectionString);
             kormBuilder.InitDatabaseForIdGenerator();
 
             CheckTableAndProcedure();
         }
-
-        private KormBuilder CreateKormBuilder(bool autoMigrate)
-            => new KormBuilder(new ServiceCollection(), ServerHelper.Connection.ConnectionString, autoMigrate);
 
         private void CheckTableAndProcedure()
         {

--- a/tests/ServiceCollectionExtensionsShould.cs
+++ b/tests/ServiceCollectionExtensionsShould.cs
@@ -11,6 +11,8 @@ namespace Kros.KORM.Extensions.Api.UnitTests
 {
     public class ServiceCollectionExtensionsShould
     {
+        private const string DefaultProviderName = Kros.Data.SqlServer.SqlServerDataHelper.ClientId;
+
         [Fact]
         public void AddKormToContainer()
         {
@@ -31,7 +33,7 @@ namespace Kros.KORM.Extensions.Api.UnitTests
 
             KormBuilder builder = services.AddKorm(configuration);
 
-            builder.ConnectionString.Should().Be(configuration.GetConnectionString("DefaultConnection"));
+            builder.ConnectionSettings.ConnectionString.Should().Be(configuration.GetConnectionString("DefaultConnection"));
         }
 
         [Fact]
@@ -75,24 +77,24 @@ namespace Kros.KORM.Extensions.Api.UnitTests
         }
 
         [Theory]
-        [InlineData("server=localhost;", KormBuilder.DefaultProviderName, false)]
-        [InlineData("server=localhost;KormProvider=", KormBuilder.DefaultProviderName, false)]
-        [InlineData("server=localhost;KormProvider=' \t '", KormBuilder.DefaultProviderName, false)]
+        [InlineData("server=localhost;", DefaultProviderName, false)]
+        [InlineData("server=localhost;KormProvider=", DefaultProviderName, false)]
+        [InlineData("server=localhost;KormProvider=' \t '", DefaultProviderName, false)]
         [InlineData("server=localhost;KormProvider=LoremIpsum", "LoremIpsum", false)]
-        [InlineData("server=localhost;KormAutoMigrate=true", KormBuilder.DefaultProviderName, true)]
-        [InlineData("server=localhost;KormAutoMigrate=false", KormBuilder.DefaultProviderName, false)]
-        [InlineData("server=localhost;KormAutoMigrate=InvalidValue", KormBuilder.DefaultProviderName, false)]
-        [InlineData("server=localhost;KormAutoMigrate=", KormBuilder.DefaultProviderName, false)]
-        [InlineData("server=localhost;KormAutoMigrate=' \t '", KormBuilder.DefaultProviderName, false)]
+        [InlineData("server=localhost;KormAutoMigrate=true", DefaultProviderName, true)]
+        [InlineData("server=localhost;KormAutoMigrate=false", DefaultProviderName, false)]
+        [InlineData("server=localhost;KormAutoMigrate=InvalidValue", DefaultProviderName, false)]
+        [InlineData("server=localhost;KormAutoMigrate=", DefaultProviderName, false)]
+        [InlineData("server=localhost;KormAutoMigrate=' \t '", DefaultProviderName, false)]
         public void ParseKormConnectionStringKeys(string connectionString, string provider, bool autoMigrate)
         {
             var services = new ServiceCollection();
 
             KormBuilder builder = services.AddKorm(connectionString);
 
-            builder.KormProvider.Should().Be(provider);
-            builder.AutoMigrate.Should().Be(autoMigrate);
-            builder.ConnectionString.Should().Be("server=localhost");
+            builder.ConnectionSettings.KormProvider.Should().Be(provider);
+            builder.ConnectionSettings.AutoMigrate.Should().Be(autoMigrate);
+            builder.ConnectionSettings.ConnectionString.Should().Be("server=localhost");
         }
 
         [Fact]


### PR DESCRIPTION
* Migrations middleware supports multiple databases. To migrate specific database, add its name to the URL: `/kormmigration/dbname`. If the name is not specified (middleware is called with just `/kormmigration` URL), deafult connection string name will be used: `DefaultConnection`.
* This PR introduces small breaking change. Endpoint URL for migrations is `/kormmigration` to make it consistent with documentation (was `/kormmigrate` before).