### PR TITLE
Use explicit task for publishing test results

### DIFF
--- a/build-ci.yml
+++ b/build-ci.yml
@@ -7,29 +7,22 @@ trigger:
 pool:
   name: Default
 
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: DevShared/Templates
+
 variables:
-  - group: Nuget
   - name: buildConfiguration
     value: 'Release'
-  - name: projectName
-    value: 'Kros.KORM.Extensions.Asp'
 
 steps:
-  - task: DotNetCoreCLI@2
-    displayName: 'Nuget restore'
-    inputs:
-      command: 'restore'
-      projects: '**/$(projectName).csproj'
-
   - task: DotNetCoreCLI@2
     displayName: 'Build'
     inputs:
       command: build
-      projects: '**/$(projectName).csproj'
-      arguments: '--configuration $(BuildConfiguration) --no-restore'
+      projects: '**/*.csproj'
+      arguments: '--configuration $(BuildConfiguration)'
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Tests'
-    inputs:
-      command: test
-      projects: '**/*Tests*.csproj'
+  - template: steps/dotnet-test-and-publish-results.yml@templates

--- a/build.yml
+++ b/build.yml
@@ -12,38 +12,25 @@ resources:
       name: DevShared/Templates
 
 variables:
-  - group: Nuget
   - name: buildConfiguration
     value: 'Release'
-  - name: projectName
-    value: 'Kros.KORM.Extensions.Asp'
 
 steps:
   - template: steps/delete-nupkgs.yml@templates
 
   - task: DotNetCoreCLI@2
-    displayName: 'Nuget restore'
-    inputs:
-      command: 'restore'
-      projects: '**/$(projectName).csproj'
-
-  - task: DotNetCoreCLI@2
     displayName: 'Build'
     inputs:
       command: build
-      projects: '**/$(projectName).csproj'
-      arguments: '--configuration $(BuildConfiguration) --no-restore'
+      projects: '**/*.csproj'
+      arguments: '--configuration $(BuildConfiguration)'
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Tests'
-    inputs:
-      command: test
-      projects: '**/*Tests*.csproj'
+  - template: steps/dotnet-test-and-publish-results.yml@templates
 
   - task: CopyFiles@2
     displayName: 'Copy package files to staging directory'
     inputs:
-      Contents: '**/$(projectName)*.nupkg'
+      Contents: '**/*.nupkg'
       TargetFolder: '$(build.artifactStagingDirectory)'
       FlattenFolders: true
 


### PR DESCRIPTION
Fixes slow runs of pipelines, because of some bug in [DotNetCoreCLI@2](https://github.com/microsoft/azure-pipelines-tasks/issues/11831) task.